### PR TITLE
shebang to run script with `./script` notation

### DIFF
--- a/obsidian_to_anki.py
+++ b/obsidian_to_anki.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """Script for adding cards to Anki from Obsidian."""
 
 import re


### PR DESCRIPTION
this doesnt affect present functionality of script, but allows someone (like me) to 

```bash
chmod +x obsidian_to_anki.py
./obsidian_to_anki.py
```