### PR TITLE
Remove only the newline added by the script

### DIFF
--- a/obsidian_to_anki.py
+++ b/obsidian_to_anki.py
@@ -1028,7 +1028,7 @@ class File:
 
     def write_file(self):
         """Write to the actual os file"""
-        self.file = self.file.strip()  # Remove newline added
+        self.file = self.file[:-1]  # Remove newline added
         write_safe(self.filename, self.file)
 
     def get_add_notes(self):


### PR DESCRIPTION
Although the script adds a single line at the end of Markdown files in the process of creating cards, it strips all whitespace characters at the end even if those characters existed before running the script.

I’ve updated the script to only remove a single newline character added at the end. This is useful for people who end files with a newline character (or have configured their editors to do so automatically) and don’t want those characters to be removed.