### PR TITLE
Fixed set configfile encoding to utf-8

### DIFF
--- a/obsidian_to_anki.py
+++ b/obsidian_to_anki.py
@@ -909,7 +909,7 @@ class App:
                 CONFIG_DATA["Added Media"].setdefault(
                     filename, "True"
                 )
-            with open(CONFIG_PATH, "w") as configfile:
+            with open(CONFIG_PATH, "w", encoding='utf_8') as configfile:
                 Config.config.write(configfile)
             tags = AnkiConnect.parse(result[0])
             directory_responses = result[2:]


### PR DESCRIPTION
If configfile too many chinese, write file will set encoding to GB2312.