### PR TITLE
Way to skip scanning of files that haven't been modified since the last scan.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ If you set 'GUI' in the config file to False, the script is then run from the co
 * Use `-m` to force the script to add all media files detected, instead of lazy addition of media files. Useful if you've e.g. resized the image, and want the changes to be reflected in Anki.
 * Use `-r` to use custom regex syntax, ignoring the default syntax of the script.
 * Use `-R` to recursively scan subfolders.
+* Use `-F` to skip scanning files that have not been modified since the last scan (It's much faster). This must be used with the `-R` flag.
 
 ## New users
 

--- a/obsidian_to_anki_config.ini
+++ b/obsidian_to_anki_config.ini
@@ -61,6 +61,8 @@ Cloze =
 
 [Added Media]
 
+[File Hashes]
+
 [Obsidian]
 Vault name = 
 


### PR DESCRIPTION
Scanning files that haven't been modified since the last scan is a pain in recursive scanning (especially when these files are quite large). This helps skip scanning these unmodified files using the `-F` flag.

```
python3 obsidian_to_anki.py -r -R -F './'
```
PS
The file contents are hashed and the hash stored as an entry in the config file i.e. under [File Hashes]. This compensates for users changing file name or file location.
Non-cryptographic hashing functions like murmurhash are much faster than cryptographic ones but I used SHA-1 since I couldn't find any non-cryptographic hash in the Python standard library.

PPS
Thanks for this great tool :)