### PR TITLE
fix: Bug obsidian tags not being added for regex notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+main.js
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-main.js
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/note.ts
+++ b/src/note.ts
@@ -302,6 +302,14 @@ export class RegexNote {
 		if (this.note_type.includes("Cloze") && !(note_has_clozes(template))) {
 			this.identifier = CLOZE_ERROR //An error code that says "don't add this note!"
 		}
+        if (data.add_obs_tags) {
+			for (let key in template["fields"]) {
+				for (let match of template["fields"][key].matchAll(OBS_TAG_REGEXP)) {
+					this.tags.push(match[1])
+				}
+				template["fields"][key] = template["fields"][key].replace(OBS_TAG_REGEXP, "")
+	        }
+		}
 		template["tags"].push(...this.tags)
         template["deckName"] = deck
 		return {note: template, identifier: this.identifier}

--- a/src/note.ts
+++ b/src/note.ts
@@ -302,7 +302,7 @@ export class RegexNote {
 		if (this.note_type.includes("Cloze") && !(note_has_clozes(template))) {
 			this.identifier = CLOZE_ERROR //An error code that says "don't add this note!"
 		}
-        if (data.add_obs_tags) {
+		if (data.add_obs_tags) {
 			for (let key in template["fields"]) {
 				for (let match of template["fields"][key].matchAll(OBS_TAG_REGEXP)) {
 					this.tags.push(match[1])

--- a/tests/anki/test_question_answer.py
+++ b/tests/anki/test_question_answer.py
@@ -24,7 +24,7 @@ def test_deck_default_exists(col: Collection):
     assert col.decks.id_for_name('Default') is not None
 
 def test_cards_count(col: Collection):
-    assert len(col.find_cards( col.build_search_string(SearchNode(deck='Default')) )) == 4
+    assert len(col.find_cards( col.build_search_string(SearchNode(deck='Default')) )) == 5
 
 def test_cards_ids_from_obsidian(col: Collection):
 
@@ -63,7 +63,14 @@ def test_cards_front_back_tag_type(col: Collection):
     assert note4.fields[0] == "How is this possible?"
     assert note4.fields[1] == "The 'magic' of regular expressions!"
 
+    note5 = col.get_note(anki_IDs[4])
+    assert note5.fields[0] == "How is this possible? "
+    assert note5.fields[1] == "The 'magic' of regular expressions! "
+    assert note5.has_tag('tag2')
+    assert note5.has_tag('tag1')
+
     assert note1.note_type()["name"] == "Basic"
     assert note2.note_type()["name"] == "Basic"
     assert note3.note_type()["name"] == "Basic"
     assert note4.note_type()["name"] == "Basic"
+    assert note5.note_type()["name"] == "Basic"

--- a/tests/defaults/test_vault_suites/question_answer/.obsidian/plugins/obsidian-to-anki-plugin/data.json
+++ b/tests/defaults/test_vault_suites/question_answer/.obsidian/plugins/obsidian-to-anki-plugin/data.json
@@ -37,7 +37,7 @@
       "CurlyCloze": true,
       "CurlyCloze - Highlights to Clozes": false,
       "ID Comments": true,
-      "Add Obsidian Tags": false
+      "Add Obsidian Tags": true
     }
   },
   "Added Media": [],

--- a/tests/defaults/test_vault_suites/question_answer/question_answer.md
+++ b/tests/defaults/test_vault_suites/question_answer/question_answer.md
@@ -19,3 +19,7 @@ A: No, and preceding whitespace will be ignored.
 <!-- CARD -->
 Q: How is this possible?
 A: The 'magic' of regular expressions!
+
+<!-- CARD -->
+Q: How is this possible? #tag2
+A: The 'magic' of regular expressions! #tag1


### PR DESCRIPTION
This should fix #196 where Obsidian tags in regex notes aren't added to Anki.