### PR TITLE
Add Obsidian Tags for Regex notes

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -302,6 +302,14 @@ export class RegexNote {
 		if (this.note_type.includes("Cloze") && !(note_has_clozes(template))) {
 			this.identifier = CLOZE_ERROR //An error code that says "don't add this note!"
 		}
+		if (data.add_obs_tags) {
+			for (let key in template["fields"]) {
+				for (let match of template["fields"][key].matchAll(OBS_TAG_REGEXP)) {
+					this.tags.push(match[1])
+				}
+				template["fields"][key] = template["fields"][key].replace(OBS_TAG_REGEXP, "")
+	        }
+		}
 		template["tags"].push(...this.tags)
         template["deckName"] = deck
 		return {note: template, identifier: this.identifier}


### PR DESCRIPTION
The "Add Obsidian Tags" is not implemented for regex notes. It is still possible to specify tags using the "Tags: tag_1 tag_2 ..."  pattern, as described in the wiki.

I am missing being able to specify them in the header as Obsidian tags using the Neurocache flashcard style, though, which is possible in non-regex notes. For example, the following should add the tag "kings" to the note (along with context or folder-specific tags).

```
What is the name of the king? #kings #flashcard
Great Larry.
```

This small change should make that possible, or am I wrong?