### PR TITLE
Add space between double curly braces to fix issues with cloze cards

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -68,11 +68,15 @@ export class FormatConverter {
 	}
 
 	obsidian_to_anki_math(note_text: string): string {
+		const replaceDoubleCurlyBraces = (input: string): string => {
+			return input.replace(/{{/g, "{ {").replace(/}}/g, "} }")
+		}
+
 		return note_text.replace(
-				c.OBS_DISPLAY_MATH_REGEXP, "\\[$1\\]"
+				c.OBS_DISPLAY_MATH_REGEXP, (match, p1) => `\\[${replaceDoubleCurlyBraces(p1)}\\]`
 		).replace(
 			c.OBS_INLINE_MATH_REGEXP,
-			"\\($1\\)"
+			(match, p1) => `\\(${replaceDoubleCurlyBraces(p1)}\\)`
 		)
 	}
 


### PR DESCRIPTION
Without spaces between double curly braces in Equations inside cloze deletions, this happens in anki:
![image](https://github.com/Pseudonium/Obsidian_to_Anki/assets/45246069/f331d2db-2450-41ce-a13d-f7660a378b0e)

If we change the math from this:
```latex
\frac{\{P\land E\} S \{P\}}{\{P\}\text{while E do S}\{P\land \lnot E\}}
```
to this:
```latex
\frac{\{P\land E\} S \{P\} }{\{P\}\text{while E do S}\{P\land \lnot E\} }
```
It solves the issue and displays the math properly when reviewing cards.

Resolves #313