### PR TITLE
fix: obsidian_setup.py can not download files when there are no corresponding resources the latest release

### DIFF
--- a/obstoanki_setup.py
+++ b/obstoanki_setup.py
@@ -3,27 +3,34 @@ import sys
 import subprocess
 import os
 
-SCRIPT_URL = "".join(
-    [
-        "https://github.com/Pseudonium/Obsidian_to_Anki/releases/latest",
-        "/download/obsidian_to_anki.py"
-    ]
-)
+SCRIPT_URL = [
+    "https://github.com/ObsidianToAnki/Obsidian_to_Anki/releases/latest/download/obsidian_to_anki.py",
+    "https://raw.githubusercontent.com/ObsidianToAnki/Obsidian_to_Anki/master/obsidian_to_anki.py",
+]
 
-REQUIRE_URL = "".join(
-    [
-        "https://github.com/Pseudonium/Obsidian_to_Anki/releases/latest",
-        "/download/requirements.txt"
-    ]
-)
 
-with urllib.request.urlopen(SCRIPT_URL) as script:
-    with open("obsidian_to_anki.py", "wb") as f:
-        f.write(script.read())
+REQUIRE_URL = [
+    "https://github.com/ObsidianToAnki/Obsidian_to_Anki/releases/latest/download/requirements.txt",
+    "https://raw.githubusercontent.com/ObsidianToAnki/Obsidian_to_Anki/master/requirements.txt",
+]
 
-with urllib.request.urlopen(REQUIRE_URL) as require:
-    with open("obstoankirequire.txt", "wb") as f:
-        f.write(require.read())
+def download_file(urls, filename) :
+    for url in urls:
+        try:
+            with urllib.request.urlopen(url) as response:
+                with open(filename, "wb") as f:
+                    f.write(response.read())
+            print(f"Successfully downloaded {filename}.")
+            return True
+        except Exception as e:
+            print(f"An error occurred while downloading {filename} from {url}: {e}")
+
+    print(f"Failed to download {filename} using all provided URLs.")
+    return False
+
+download_file(SCRIPT_URL, "obsidian_to_anki.py")
+
+if download_file(REQUIRE_URL, "obstoankirequire.txt"):
     subprocess.check_call(
         [sys.executable, "-m", "pip", "install", "-r", "obstoankirequire.txt"]
     )


### PR DESCRIPTION
when obsidian_to_anki.py and requirements.txt are not existed in the latest release page like this picture, runing `python obsidian_setup.py` will failed because `HTTP Error 404: Not Found`，so i submitted this pr to solve this bug
![image](https://github.com/ObsidianToAnki/Obsidian_to_Anki/assets/108139896/06b51d7f-f571-4e98-9e3a-80b4372bf50b)
I just fix this bug by using the url like https://raw.githubusercontent.com/ObsidianToAnki/Obsidian_to_Anki/master as the backup url when failing to download it from the release page.

This PR can help novice users install better. 

Also, I am a beginner in open source, so please raise any concerns.