### PR TITLE
fix matching html content as obsidian tags

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -12,7 +12,7 @@ const TAG_PREFIX:string = "Tags: "
 export const TAG_SEP:string = " "
 export const ID_REGEXP_STR: string = String.raw`\n?(?:<!--)?(?:ID: (\d+).*)`
 export const TAG_REGEXP_STR: string = String.raw`(Tags: .*)`
-const OBS_TAG_REGEXP: RegExp = /#(\w+)/g
+const OBS_TAG_REGEXP: RegExp = /(?:&#\d+;)|#(\w+)/g
 
 const ANKI_CLOZE_REGEXP: RegExp = /{{c\d+::[\s\S]+?}}/
 export const CLOZE_ERROR: number = 42


### PR DESCRIPTION
addresses #536 

This regex matches obsidian tag style `#my-tag` only if it's not part of an HTML expression, e.g. from #536, `&#039;` will be matched and skipped over.