### PR TITLE
fix: 551 correction of obsidian tags

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -12,7 +12,7 @@ const TAG_PREFIX:string = "Tags: "
 export const TAG_SEP:string = " "
 export const ID_REGEXP_STR: string = String.raw`\n?(?:<!--)?(?:ID: (\d+).*)`
 export const TAG_REGEXP_STR: string = String.raw`(Tags: .*)`
-const OBS_TAG_REGEXP: RegExp = /#(\w+)/g
+const OBS_TAG_REGEXP: RegExp = /#([\w\u4e00-\u9fa5]+)/g
 
 const ANKI_CLOZE_REGEXP: RegExp = /{{c\d+::[\s\S]+?}}/
 export const CLOZE_ERROR: number = 42

--- a/src/note.ts
+++ b/src/note.ts
@@ -12,7 +12,7 @@ const TAG_PREFIX:string = "Tags: "
 export const TAG_SEP:string = " "
 export const ID_REGEXP_STR: string = String.raw`\n?(?:<!--)?(?:ID: (\d+).*)`
 export const TAG_REGEXP_STR: string = String.raw`(Tags: .*)`
-const OBS_TAG_REGEXP: RegExp = /#([\w\u4e00-\u9fa5]+)/g
+const OBS_TAG_REGEXP: RegExp = /#([\p{L}\p{N}\p{Emoji}\p{M}_/-]+)/gu
 
 const ANKI_CLOZE_REGEXP: RegExp = /{{c\d+::[\s\S]+?}}/
 export const CLOZE_ERROR: number = 42


### PR DESCRIPTION
Closes #551 

Possible fix to the regex of `OBS_TAG_REGEXP`

With the new changes, it now detects chinese characters correctly.