### PR TITLE
A more efficient way of updating tags + Scan current file only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "obsidian-to-anki-plugin",
-    "version": "3.4.2",
+    "version": "3.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "obsidian-to-anki-plugin",
-            "version": "3.4.2",
+            "version": "3.6.0",
             "license": "MIT",
             "dependencies": {
                 "byte-base64": "^1.1.0",

--- a/src/anki.ts
+++ b/src/anki.ts
@@ -105,19 +105,10 @@ export function changeDeck(card_ids: number[], deck: string): AnkiConnectRequest
 	)
 }
 
-export function removeTags(note_ids: number[], tags: string): AnkiConnectRequest {
+export function updateNoteTags(note_id: number, tags: string[]): AnkiConnectRequest {
 	return request(
-		'removeTags', {
-			notes: note_ids,
-			tags: tags
-		}
-	)
-}
-
-export function addTags(note_ids: number[], tags: string): AnkiConnectRequest {
-	return request(
-		'addTags', {
-			notes: note_ids,
+		'updateNoteTags', {
+			note: note_id,
 			tags: tags
 		}
 	)

--- a/src/file.ts
+++ b/src/file.ts
@@ -231,19 +231,12 @@ abstract class AbstractFile {
         return AnkiConnect.changeDeck(this.card_ids, this.target_deck)
     }
 
-    getClearTags(): AnkiConnect.AnkiConnectRequest {
-        let IDs: number[] = []
-        for (let parsed of this.notes_to_edit) {
-            IDs.push(parsed.identifier)
-        }
-        return AnkiConnect.removeTags(IDs, this.tags.join(" "))
-    }
-
-    getAddTags(): AnkiConnect.AnkiConnectRequest {
+    getUpdateTags(): AnkiConnect.AnkiConnectRequest {
         let actions: AnkiConnect.AnkiConnectRequest[] = []
         for (let parsed of this.notes_to_edit) {
+            let tags = parsed.note.tags.join(" ") + " " + this.global_tags
             actions.push(
-                AnkiConnect.addTags([parsed.identifier], parsed.note.tags.join(" ") + " " + this.global_tags)
+                AnkiConnect.updateNoteTags(parsed.identifier, tags.split(" "))
             )
         }
         return AnkiConnect.multi(actions)

--- a/src/files-manager.ts
+++ b/src/files-manager.ts
@@ -306,21 +306,19 @@ export class FileManager {
         let temp: AnkiConnect.AnkiConnectRequest[] = []
         console.info("Requesting cards to be moved to target deck...")
         for (let file of this.ownFiles) {
-            temp.push(file.getChangeDecks())
+            let deck = file.getChangeDecks()
+            if (deck.params.cards && deck.params.cards.length) {
+              temp.push(deck)
+            }
         }
         requests.push(AnkiConnect.multi(temp))
         temp = []
         console.info("Requesting tags to be replaced...")
         for (let file of this.ownFiles) {
-            let rem = file.getClearTags()
-            if(rem.params.notes.length) {
-                temp.push(rem)
+            let update = file.getUpdateTags()
+            if(update.params.actions.length) {
+              temp.push(update)
             }
-        }
-        requests.push(AnkiConnect.multi(temp))
-        temp = []
-        for (let file of this.ownFiles) {
-            temp.push(file.getAddTags())
         }
         requests.push(AnkiConnect.multi(temp))
         temp = []

--- a/tests/defaults/test_vault/.obsidian/plugins/obsidian-to-anki-plugin/manifest.json
+++ b/tests/defaults/test_vault/.obsidian/plugins/obsidian-to-anki-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-to-anki-plugin",
   "name": "Obsidian_to_Anki",
-  "version": "3.4.2",
+  "version": "3.6.0",
   "minAppVersion": "0.9.20",
   "description": "This is an Anki integration plugin! Designed for efficient bulk exporting.",
   "author": "Pseudonium",


### PR DESCRIPTION
This pull request is just a more efficient way of updating tags (using updateNoteTags vs. removeTags + addTags). This speeds up the generation task, especially if you have a big vault (2k notes) and a lot of tags in Anki (64k cards with ~16k tags). Alltogehter It should prevent Anki from dying due to a big request-payload.

Moreover, I added a command to scan the current file only.

![image](https://github.com/ObsidianToAnki/Obsidian_to_Anki/assets/11216162/c01c9187-aae0-4900-aaf6-88594734354a)

This should fix #565. Maybe helps on #428, #354, #326.
