### PR TITLE
fix: 219 correctly handle dolar symbol in decensor function

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -134,13 +134,12 @@ export class FormatConverter {
 		return [note_text.replace(regexp, mask), matches]
 	}
 
-	decensor(note_text: string, mask:string, replacements: string[], escape: boolean): string {
-		for (let replacement of replacements) {
-			note_text = note_text.replace(
-				mask, escape ? escapeHtml(replacement) : replacement
-			)
-		}
-		return note_text
+	decensor(note_text: string, mask: string, replacements: string[], escape: boolean): string {
+		let i = 0;
+		return note_text.replace(new RegExp(mask, 'g'), (): string => {
+			let replacement: string = replacements[i++];
+			return escape ? escapeHtml(replacement) : replacement;
+		});
 	}
 
 	format(note_text: string, cloze: boolean, highlights_to_cloze: boolean): string {

--- a/src/format.ts
+++ b/src/format.ts
@@ -135,11 +135,27 @@ export class FormatConverter {
 	}
 
 	decensor(note_text: string, mask: string, replacements: string[], escape: boolean): string {
-		let i = 0;
-		return note_text.replace(new RegExp(mask, 'g'), (): string => {
-			let replacement: string = replacements[i++];
+		let index = 0;
+
+		// note_text example: "The OBSTOANKICODEDISPLAY is worth OBSTOANKICODEDISPLAY today"
+		// maskGlobalReg example: /OBSTOANKICODEDISPLAY/g
+		const maskGlobalRegex: RegExp = new RegExp(mask, 'g');
+
+		const matchCount: number = (note_text.match(maskGlobalRegex) || []).length;
+
+		// Validate that we have exactly enough replacements
+		if (matchCount !== replacements.length) {
+			throw new Error(`Mismatch between placeholders (${matchCount}) and replacements (${replacements.length})`);
+		}
+
+		// replacements example: ["10", "15"]
+		note_text = note_text.replace(maskGlobalRegex, () => {
+			const replacement: string = replacements[index++];
 			return escape ? escapeHtml(replacement) : replacement;
 		});
+
+		// note_text expected: "The 10 is worth 15 today"
+		return note_text;
 	}
 
 	format(note_text: string, cloze: boolean, highlights_to_cloze: boolean): string {


### PR DESCRIPTION
Closes #219 

- Implement counter to ensure each replacement is used once and in order
- Use global `g` flag in RegExp to handle all occurrences of the mask

