### PR TITLE
Don't bail when START, END, or note type are followed by a space

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -135,7 +135,7 @@ export class Note extends AbstractNote {
     }
 
     getNoteType(): string {
-        return this.split_text[0]
+        return this.split_text[0].trim()
     }
 
     fieldFromLine(line: string): [string, string] {
@@ -204,7 +204,7 @@ export class InlineNote extends AbstractNote {
     getNoteType(): string {
         const result = this.text.match(InlineNote.TYPE_REGEXP)
         this.text = this.text.slice(result.index + result[0].length)
-        return result[1]
+        return result[1].trim()
     }
 
     getFields(): Record<string, string> {

--- a/src/setting-to-data.ts
+++ b/src/setting-to-data.ts
@@ -31,7 +31,7 @@ export async function settingToData(app: App, settings: PluginSettings, fields_d
     result.FROZEN_REGEXP = new RegExp(escapeRegex(settings.Syntax["Frozen Fields Line"]) + String.raw` - (.*?):\n((?:[^\n][\n]?)+)`, "g")
     result.DECK_REGEXP = new RegExp(String.raw`^` + escapeRegex(settings.Syntax["Target Deck Line"]) + String.raw`(?:\n|: )(.*)`, "m")
     result.TAG_REGEXP = new RegExp(String.raw`^` + escapeRegex(settings.Syntax["File Tags Line"]) + String.raw`(?:\n|: )(.*)`, "m")
-    result.NOTE_REGEXP = new RegExp(String.raw`^` + escapeRegex(settings.Syntax["Begin Note"]) + String.raw`\n([\s\S]*?\n)` + escapeRegex(settings.Syntax["End Note"]), "gm")
+    result.NOTE_REGEXP = new RegExp(String.raw`^` + escapeRegex(settings.Syntax["Begin Note"]) + String.raw`[\s]*\n([\s\S]*?\n)` + escapeRegex(settings.Syntax["End Note"] + "[\s]*"), "gm")
     result.INLINE_REGEXP = new RegExp(escapeRegex(settings.Syntax["Begin Inline Note"]) + String.raw`(.*?)` + escapeRegex(settings.Syntax["End Inline Note"]), "g")
     result.EMPTY_REGEXP = new RegExp(escapeRegex(settings.Syntax["Delete Note Line"]) + ID_REGEXP_STR, "g")
 


### PR DESCRIPTION
This behavior was very confusing and not communicated to the user, so just allow trailing spaces.

This fixes the issue described in #484.