### PR TITLE
feat: add syntax highlighting for code blocks

### DIFF
--- a/obsidian_to_anki.py
+++ b/obsidian_to_anki.py
@@ -16,6 +16,9 @@ import socket
 import subprocess
 import logging
 import hashlib
+from pygments import highlight
+from pygments.lexers import get_lexer_by_name, guess_lexer
+from pygments.formatters import HtmlFormatter
 try:
     import gooey
     GOOEY = True
@@ -66,15 +69,24 @@ DATA_PATH = os.path.expanduser(
 md_parser = markdown.Markdown(
     extensions=[
         'fenced_code',
+        'codehilite',
         'footnotes',
         'md_in_html',
         'tables',
         'nl2br',
         'sane_lists'
-    ]
+    ],
+    extension_configs={
+        'codehilite': {
+            'linenums': False,
+            'guess_lang': True
+        }
+    }
 )
 
 ANKI_PORT = 8765
+
+CODE_CSS_URL = 'https://cdn.jsdelivr.net/npm/pygments-css@1.0.0/monokai.css'
 
 ANKI_CLOZE_REGEXP = re.compile(r'{{c\d+::[\s\S]+?}}')
 
@@ -420,22 +432,32 @@ class FormatConverter:
         )
 
     @staticmethod
+    def highlight_code_block(code, lang=''):
+        formatter = HtmlFormatter(nowrap=True)
+        if lang:
+            try:
+                lexer = get_lexer_by_name(lang, stripall=True)
+            except:
+                lexer = guess_lexer(code)
+        else:
+            lexer = guess_lexer(code)
+        return highlight(code, lexer, formatter)
+
+    @staticmethod
     def format(note_text, cloze=False):
-        """Apply all format conversions to note_text."""
+        add_highlight_css = bool(
+            FormatConverter.OBS_DISPLAY_CODE_REGEXP.search(note_text)
+        )
         note_text = FormatConverter.obsidian_to_anki_math(note_text)
-        # Extract the parts that are anki math
         math_matches = [
             math_match.group(0)
             for math_match in FormatConverter.ANKI_MATH_REGEXP.finditer(
                 note_text
             )
         ]
-        # Replace them to be later added back, so they don't interfere
-        # with markdown parsing
         note_text = FormatConverter.ANKI_MATH_REGEXP.sub(
             FormatConverter.MATH_REPLACE, note_text
         )
-        # Now same with code!
         inline_code_matches = [
             code_match.group(0)
             for code_match in FormatConverter.OBS_CODE_REGEXP.finditer(
@@ -462,14 +484,37 @@ class FormatConverter:
                 code_match,
                 1
             )
+        CODE_BLOCK_PLACEHOLDER = "OBSTOANKICODEBLOCKPLACEHOLDER"
+        code_blocks = []
+        code_index = 0
+        def save_code_block(match):
+            nonlocal code_index
+            lang = match.group(1) or ''
+            code = match.group(2)
+            code_blocks.append((lang, code))
+            result = CODE_BLOCK_PLACEHOLDER + str(code_index)
+            code_index += 1
+            return result
         for code_match in display_code_matches:
+            code_block_with_placeholder = re.sub(
+                r'```(\w*)\n([\s\S]*?)```',
+                save_code_block,
+                code_match
+            )
             note_text = note_text.replace(
                 FormatConverter.DISPLAY_CODE_REPLACE,
-                code_match,
+                code_block_with_placeholder,
                 1
             )
         note_text = FormatConverter.markdown_parse(note_text)
-        # Add back the parts that are anki math
+        for idx, (lang, code) in enumerate(code_blocks):
+            highlighted = FormatConverter.highlight_code_block(code, lang)
+            lang_class = f'{lang} language-{lang}' if lang else ''
+            code_html = f'<pre><code class="hljs {lang_class}">{highlighted}</code></pre>'
+            note_text = note_text.replace(
+                CODE_BLOCK_PLACEHOLDER + str(idx),
+                code_html
+            )
         for math_match in math_matches:
             note_text = note_text.replace(
                 FormatConverter.MATH_REPLACE,
@@ -481,7 +526,6 @@ class FormatConverter:
         note_text = FormatConverter.fix_image_src(note_text)
         note_text = FormatConverter.fix_audio_src(note_text)
         note_text = note_text.strip()
-        # Remove unnecessary paragraph tag
         if note_text.startswith(
             FormatConverter.PARA_OPEN
         ) and note_text.endswith(
@@ -489,6 +533,10 @@ class FormatConverter:
         ):
             note_text = note_text[len(FormatConverter.PARA_OPEN):]
             note_text = note_text[:-len(FormatConverter.PARA_CLOSE)]
+        if add_highlight_css:
+            note_text = '<link href="{}" rel="stylesheet">{}'.format(
+                CODE_CSS_URL, note_text
+            )
         return note_text
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "obsidian-to-anki-plugin",
-    "version": "3.4.2",
+    "version": "3.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "obsidian-to-anki-plugin",
-            "version": "3.4.2",
+            "version": "3.6.0",
             "license": "MIT",
             "dependencies": {
                 "byte-base64": "^1.1.0",
@@ -645,25 +645,6 @@
             "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
             "dev": true
         },
-        "node_modules/@testim/chrome-version": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.4.tgz",
-            "integrity": "sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -1285,27 +1266,6 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/axios": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
-            "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "follow-redirects": "^1.15.4",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "node_modules/b4a": {
             "version": "1.6.4",
             "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
@@ -1559,72 +1519,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/chrome-launcher": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.1.0.tgz",
-            "integrity": "sha512-rJYWeEAERwWIr3c3mEVXwNiODPEdMRlRxHc47B1qHPOolHZnkj7rMv1QSUfPoG6MgatWj5AxSpnKKR4QEwEQIQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*",
-                "escape-string-regexp": "^4.0.0",
-                "is-wsl": "^2.2.0",
-                "lighthouse-logger": "^2.0.1"
-            },
-            "bin": {
-                "print-chrome-path": "bin/print-chrome-path.js"
-            },
-            "engines": {
-                "node": ">=12.13.0"
-            }
-        },
-        "node_modules/chromedriver": {
-            "version": "114.0.3",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-114.0.3.tgz",
-            "integrity": "sha512-Qy5kqsAUrCDwpovM5pIWFkb3X3IgJLoorigwFEDgC1boL094svny3N7yw06marJHAuyX4CE/hhd25RarIcKvKg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@testim/chrome-version": "^1.1.3",
-                "axios": "^1.4.0",
-                "compare-versions": "^6.0.0",
-                "extract-zip": "^2.0.1",
-                "https-proxy-agent": "^5.0.1",
-                "proxy-from-env": "^1.1.0",
-                "tcp-port-used": "^1.0.1"
-            },
-            "bin": {
-                "chromedriver": "bin/chromedriver"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/chromium-bidi": {
-            "version": "0.4.9",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.9.tgz",
-            "integrity": "sha512-u3DC6XwgLCA9QJ5ak1voPslCmacQdulZNCPsI3qNXxSnEcZS7DFIbww+5RM2bznMEje7cc0oydavRLRvOIZtHw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "mitt": "3.0.0"
-            },
-            "peerDependencies": {
-                "devtools-protocol": "*"
-            }
-        },
         "node_modules/ci-info": {
             "version": "3.9.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -1767,20 +1661,6 @@
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
             "dev": true
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/commander": {
             "version": "9.5.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -1794,14 +1674,6 @@
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
             "dev": true
-        },
-        "node_modules/compare-versions": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
-            "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "node_modules/compress-commons": {
             "version": "5.0.1",
@@ -1858,39 +1730,6 @@
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
-        },
-        "node_modules/cross-fetch": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
-            "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "node-fetch": "^2.6.11"
-            }
-        },
-        "node_modules/cross-fetch/node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -2075,17 +1914,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/dequal": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2094,41 +1922,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/devtools": {
-            "version": "8.27.0",
-            "resolved": "https://registry.npmjs.org/devtools/-/devtools-8.27.0.tgz",
-            "integrity": "sha512-yvCfYN/TUlYoeIhW+eYnPnHLR7C0z+SBEGi0jEWk7q7Gr+/s8SvDR+GHNYRkihffkdnDwkM6Ew2nBOWqtczlug==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node": "^20.1.0",
-                "@wdio/config": "8.27.0",
-                "@wdio/logger": "8.24.12",
-                "@wdio/protocols": "8.24.12",
-                "@wdio/types": "8.27.0",
-                "@wdio/utils": "8.27.0",
-                "chrome-launcher": "^1.0.0",
-                "edge-paths": "^3.0.5",
-                "import-meta-resolve": "^4.0.0",
-                "puppeteer-core": "20.3.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "ua-parser-js": "^1.0.1",
-                "uuid": "^9.0.0",
-                "which": "^4.0.0"
-            },
-            "engines": {
-                "node": "^16.13 || >=18"
-            }
-        },
-        "node_modules/devtools-protocol": {
-            "version": "0.0.1120988",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
-            "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "node_modules/diff": {
             "version": "5.1.0",
@@ -2606,28 +2399,6 @@
                 "flat": "cli.js"
             }
         },
-        "node_modules/follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/foreground-child": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -2641,22 +2412,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/form-data-encoder": {
@@ -2677,14 +2432,6 @@
             "engines": {
                 "node": ">=12.20.0"
             }
-        },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "node_modules/fs-extra": {
             "version": "8.1.0",
@@ -3081,35 +2828,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/https-proxy-agent/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
         "node_modules/human-signals": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -3255,23 +2973,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3375,20 +3076,6 @@
             "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
             "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
             "dev": true
-        },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/is2": {
             "version": "2.0.9",
@@ -3983,37 +3670,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/lighthouse-logger": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.1.tgz",
-            "integrity": "sha512-ioBrW3s2i97noEmnXxmUq7cjIcVRjT5HBpAYy8zE11CxU9HqlWHHeRxfeN1tn8F7OEMVPIC9x1f8t3Z7US9ehQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "^2.6.9",
-                "marky": "^1.2.2"
-            }
-        },
-        "node_modules/lighthouse-logger/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/lighthouse-logger/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "node_modules/lines-and-columns": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
@@ -4250,14 +3906,6 @@
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
         },
-        "node_modules/marky": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-            "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4275,31 +3923,6 @@
             },
             "engines": {
                 "node": ">=8.6"
-            }
-        },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/mimic-fn": {
@@ -5174,159 +4797,6 @@
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
-            }
-        },
-        "node_modules/puppeteer-core": {
-            "version": "20.3.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.3.0.tgz",
-            "integrity": "sha512-264pBrIui5bO6NJeOcbJrLa0OCwmA4+WK00JMrLIKTfRiqe2gx8KWTzLsjyw/bizErp3TKS7vt/I0i5fTC+mAw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@puppeteer/browsers": "1.3.0",
-                "chromium-bidi": "0.4.9",
-                "cross-fetch": "3.1.6",
-                "debug": "4.3.4",
-                "devtools-protocol": "0.0.1120988",
-                "ws": "8.13.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.3.0.tgz",
-            "integrity": "sha512-an3QdbNPkuU6qpxpbssxAbjRLJcF+eP4L8UqIY3+6n0sbaVxw5pz7PiCLy9g32XEZuoamUlV5ZQPnA6FxvkIHA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "4.3.4",
-                "extract-zip": "2.0.1",
-                "http-proxy-agent": "5.0.0",
-                "https-proxy-agent": "5.0.1",
-                "progress": "2.0.3",
-                "proxy-from-env": "1.1.0",
-                "tar-fs": "2.1.1",
-                "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.1"
-            },
-            "bin": {
-                "browsers": "lib/cjs/main-cli.js"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/yargs": {
-            "version": "17.7.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-            "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/query-selector-shadow-dom": {
@@ -6409,31 +5879,6 @@
                 "node": ">=14.17"
             }
         },
-        "node_modules/ua-parser-js": {
-            "version": "1.0.37",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
-            "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/ua-parser-js"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/faisalman"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/faisalman"
-                }
-            ],
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/unbzip2-stream": {
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -6512,21 +5957,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
         },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Gooey==1.0.4.0.0.0
 Markdown==3.2.2
+pygments>=2.0.0

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,22 @@ export const OBS_DISPLAY_MATH_REGEXP: RegExp = /\$\$([\s\S]*?)\$\$/g
 export const OBS_CODE_REGEXP:RegExp = /(?<!`)`(?=[^`])[\s\S]*?`/g
 export const OBS_DISPLAY_CODE_REGEXP:RegExp = /```[\s\S]*?```/g
 
-export const CODE_CSS_URL = `https://cdn.jsdelivr.net/npm/highlightjs-themes@1.0.0/arta.css`
+// Inline CSS for syntax highlighting (solarized-light theme from highlight.js)
+// This is embedded directly in HTML since Anki doesn't support external CSS links
+export const CODE_HIGHLIGHT_CSS: string = `<style>
+.hljs{display:block;overflow-x:auto;padding:0.5em;background:#fdf6e3;color:#657b83;font-size:12px;font-family:monospace;-webkit-text-size-adjust:none}
+.hljs-comment,.diff .hljs-header,.hljs-doctype,.hljs-pi,.lisp .hljs-string,.hljs-javadoc{color:#93a1a1}
+.hljs-keyword,.hljs-winutils,.method,.hljs-addition,.css .hljs-tag,.hljs-request,.hljs-status,.nginx .hljs-title{color:#859900}
+.hljs-number,.hljs-command,.hljs-string,.hljs-tag .hljs-value,.hljs-rule .hljs-value,.hljs-phpdoc,.hljs-dartdoc,.tex .hljs-formula,.hljs-regexp,.hljs-hexcolor,.hljs-link_url{color:#2aa198}
+.hljs-title,.hljs-localvars,.hljs-chunk,.hljs-decorator,.hljs-built_in,.hljs-identifier,.vhdl .hljs-literal,.hljs-id,.css .hljs-function,.hljs-name{color:#268bd2}
+.hljs-attribute,.hljs-variable,.lisp .hljs-body,.smalltalk .hljs-number,.hljs-constant,.hljs-class .hljs-title,.hljs-parent,.hljs-type,.hljs-link_reference{color:#b58900}
+.hljs-preprocessor,.hljs-preprocessor .hljs-keyword,.hljs-pragma,.hljs-shebang,.hljs-symbol,.hljs-symbol .hljs-string,.diff .hljs-change,.hljs-special,.hljs-attr_selector,.hljs-subst,.hljs-cdata,.css .hljs-pseudo,.hljs-header{color:#cb4b16}
+.hljs-deletion,.hljs-important{color:#dc322f}
+.hljs-link_label{color:#6c71c4}
+.tex .hljs-formula{background:#eee8d5}
+</style>`
+
+export const CODE_CSS_URL = `https://cdn.jsdelivr.net/npm/highlightjs-themes@1.0.0/solarized_light.css`
 
 export function escapeRegex(str: string): string {
     // Got from stackoverflow - https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript

--- a/src/format.ts
+++ b/src/format.ts
@@ -3,8 +3,7 @@ import { basename, extname } from 'path'
 import { Converter } from 'showdown'
 import { CachedMetadata } from 'obsidian'
 import * as c from './constants'
-
-import showdownHighlight from 'showdown-highlight'
+import hljs from 'highlight.js'
 
 const ANKI_MATH_REGEXP:RegExp = /(\\\[[\s\S]*?\\\])|(\\\([\s\S]*?\\\))/g
 const HIGHLIGHT_REGEXP:RegExp = /==(.*?)==/g
@@ -28,8 +27,7 @@ let converter: Converter = new Converter({
 	literalMidWordUnderscores: true,
 	tables: true, tasklists: true,
 	simpleLineBreaks: true,
-	requireSpaceBeforeHeadingText: true,
-	extensions: [showdownHighlight]
+	requireSpaceBeforeHeadingText: true
 })
 
 function escapeHtml(unsafe: string): string {
@@ -143,6 +141,18 @@ export class FormatConverter {
 		return note_text
 	}
 
+	highlight_code_block(code: string, lang: string): string {
+		/*Highlight code using highlight.js and return HTML.*/
+		let highlighted: string
+		if (lang && hljs.getLanguage(lang)) {
+			highlighted = hljs.highlight(code, { language: lang }).value
+		} else {
+			highlighted = hljs.highlightAuto(code).value
+		}
+		const langClass = lang ? `${lang} language-${lang}` : ''
+		return `<pre><code class="hljs ${langClass}">${highlighted}</code></pre>`
+	}
+
 	format(note_text: string, cloze: boolean, highlights_to_cloze: boolean): string {
 		note_text = this.obsidian_to_anki_math(note_text)
 		//Extract the parts that are anki math
@@ -165,14 +175,27 @@ export class FormatConverter {
 		note_text = note_text.replace(HIGHLIGHT_REGEXP, String.raw`<mark>$1</mark>`)
 		note_text = this.decensor(note_text, DISPLAY_CODE_REPLACE, display_code_matches, false)
 		note_text = this.decensor(note_text, INLINE_CODE_REPLACE, inline_code_matches, false)
+		// Extract code blocks before markdown conversion to preserve them in lists
+		const CODE_BLOCK_PLACEHOLDER = "OBSTOANKICODEBLOCKPLACEHOLDER"
+		const code_blocks: Array<{lang: string, code: string}> = []
+		let code_index = 0
+		note_text = note_text.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, lang, code) => {
+			code_blocks.push({ lang: lang || '', code: code })
+			return CODE_BLOCK_PLACEHOLDER + (code_index++)
+		})
 		note_text = converter.makeHtml(note_text)
+		// Replace placeholders with highlighted code blocks
+		code_blocks.forEach((block, idx) => {
+			const code_html = this.highlight_code_block(block.code, block.lang)
+			note_text = note_text.replace(CODE_BLOCK_PLACEHOLDER + idx, code_html)
+		})
 		note_text = this.decensor(note_text, MATH_REPLACE, math_matches, true).trim()
 		// Remove unnecessary paragraph tag
 		if (note_text.startsWith(PARA_OPEN) && note_text.endsWith(PARA_CLOSE)) {
 			note_text = note_text.slice(PARA_OPEN.length, -1 * PARA_CLOSE.length)
 		}
 		if (add_highlight_css) {
-			note_text = '<link href="' + c.CODE_CSS_URL + '" rel="stylesheet">' + note_text
+			note_text = c.CODE_HIGHLIGHT_CSS + note_text
 		}
 		return note_text
 	}

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,13 @@
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@200..900&display=swap');
+
+.anki-plugin {
+  font-family: 'Inconsolata', monospace;
+}
+
 .anki-settings-table td, .anki-settings-table th {
   border: 1px solid var(--background-modifier-border);
   padding: 4px 10px;
+  font-family: 'Inconsolata', monospace;
 }
 
 .anki-settings-table {


### PR DESCRIPTION
- Add Pygments-based syntax highlighting in Python backend
- Add highlight.js-based syntax highlighting in TypeScript plugin
- Use solarized-light theme for code highlighting
- Refactor code block processing with placeholder pattern
- Add Inconsolata monospace font for UI
- Update version to 3.6.0
- Remove unused optional dependencies (chromedriver, puppeteer-core)